### PR TITLE
Fix: Clear cache only after successful DB updates

### DIFF
--- a/app/db/database_connection.py
+++ b/app/db/database_connection.py
@@ -193,8 +193,6 @@ def get_app_title():
 
 def update_app_title(new_title):
     conn = get_connection()
-    # Clear cache when title is updated
-    get_app_title.clear()
     if conn is None:
         logging.error("Failed to connect to the database.")
         return
@@ -206,6 +204,8 @@ def update_app_title(new_title):
             """, (new_title,))
             conn.commit()
             logging.info("App description updated successfully.")
+            # Clear cache only after successful update
+            get_app_title.clear()
     except Exception as e:
         logging.error(f"Error updating app title: {e}")
     finally:
@@ -215,8 +215,6 @@ def update_app_title(new_title):
 
 def update_app_description(new_description):
     conn = get_connection()
-    # Clear cache when description is updated
-    get_app_description.clear()
     if conn is None:
         logging.error("Failed to connect to the database.")
         return
@@ -228,6 +226,8 @@ def update_app_description(new_description):
             """, (new_description,))
             conn.commit()
             logging.info("App description updated successfully.")
+            # Clear cache only after successful update
+            get_app_description.clear()
     except Exception as e:
         logging.error(f"Error updating app description: {e}")
     finally:

--- a/app/instructions/instructions_handler.py
+++ b/app/instructions/instructions_handler.py
@@ -23,8 +23,6 @@ def get_latest_instructions():
 
 def update_instructions(new_instructions):
     conn = get_connection()
-    # Clear cache when instructions are updated
-    get_latest_instructions.clear()
     if conn is None:
         logging.error("Failed to connect to the database.")
         return
@@ -39,6 +37,8 @@ def update_instructions(new_instructions):
             """, (new_instructions,))
             conn.commit()
             logging.info("Instructions updated successfully.")
+            # Clear cache only after successful update
+            get_latest_instructions.clear()
     except Exception as e:
         logging.error(f"Error updating instructions: {e}")
     finally:


### PR DESCRIPTION
This pull request refines the cache clearing logic in update functions for app title, description, and instructions. Previously, caches were cleared before verifying if the database update was successful. Now, caches are only cleared after a successful update, which helps prevent stale data if an update fails.

Cache management improvements:

* Moved cache clearing (`get_app_title.clear()`, `get_app_description.clear()`, and `get_latest_instructions.clear()`) to occur only after a successful database commit in their respective update functions (`update_app_title`, `update_app_description`, and `update_instructions`) in `app/db/database_connection.py` and `app/instructions/instructions_handler.py`. [[1]](diffhunk://#diff-f5c4f7d4dd6b1c68229dcf4962de32df7e337805b12abc3c0845bba3c785babeR207-R208) [[2]](diffhunk://#diff-f5c4f7d4dd6b1c68229dcf4962de32df7e337805b12abc3c0845bba3c785babeR229-R230) [[3]](diffhunk://#diff-5386fd37f8eed67abaa76821ea4c08d7475d63bf3b6f161a06ff381444f2dba8R40-R41)

Code cleanup:

* Removed cache clearing calls from the beginning of the update functions, ensuring they are not triggered if the database connection fails or an exception occurs. [[1]](diffhunk://#diff-f5c4f7d4dd6b1c68229dcf4962de32df7e337805b12abc3c0845bba3c785babeL196-L197) [[2]](diffhunk://#diff-f5c4f7d4dd6b1c68229dcf4962de32df7e337805b12abc3c0845bba3c785babeL218-L219) [[3]](diffhunk://#diff-5386fd37f8eed67abaa76821ea4c08d7475d63bf3b6f161a06ff381444f2dba8L26-L27)Moved cache clearing for app title, description, and instructions to occur only after successful database updates, ensuring cache is not cleared if the update fails.